### PR TITLE
cmd: omit namespace in service discovery

### DIFF
--- a/cmd/nomad.go
+++ b/cmd/nomad.go
@@ -37,7 +37,7 @@ func (app *App) fetchNomadServices() (map[string]ServiceMeta, error) {
 
 // fetchServiceList retrieves the list of services from the Nomad API.
 func (app *App) fetchServiceList() ([]*api.ServiceRegistrationListStub, error) {
-	servicesList, _, err := app.nomadClient.Services().List(&api.QueryOptions{Namespace: "*"})
+	servicesList, _, err := app.nomadClient.Services().List(&api.QueryOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error listing services: %w", err)
 	}


### PR DESCRIPTION
This query for the `*` namespace only returns results from namespaces that the Nomad token has explicit access to.

By default, the workload Nomad token provided by the `identity` block has read access to all service discovery information, but does not have explicit access to any namespaces, so this query returns nothing when using it.

Therefore, omit querying for the `*` namespace.